### PR TITLE
adding support for airspy-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ and [SDRplay](http://www.sdrplay.com/) support.
 Installation
 ---
 
-Type "make".
+Type in the shell
+    
+    sudo apt-get install librtlsdr0 librtlsdr-dev libhackrf-dev libairspy-dev libsoxr-dev
+
+Next, download SDRPlay libraries from: http://www.sdrplay.com/linuxdl.php
+
+    chmod 755 SDRplay_RSP_API-Linux-2.13.1.run
+    ./SDRplay_RSP_API-Linux-2.13.1.run
+    sudo ldconfig
+
+Finally, Type "make".
 
 Normal usage
 ---


### PR DESCRIPTION
For airspy hardware, the initial code is only working for airspy-R2 (10Msps), while airspy-mini has a different sample rate of 6Msps. Additional support is thus added for airspy-mini, which is verified with real hardware. 